### PR TITLE
[NXMAPPS-708] removed the protocol flag forcing tcp. Because not all …

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -159,11 +159,11 @@ install_db() {
 
 	if ! [ -z $DB_HOSTNAME ] ; then
 		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
-			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT"
 		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
 			EXTRA=" --socket=$DB_SOCK_OR_PORT"
 		elif ! [ -z $DB_HOSTNAME ] ; then
-			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+			EXTRA=" --host=$DB_HOSTNAME"
 		fi
 	fi
 


### PR DESCRIPTION
…of our locals match, this causes issues for locals that use socket instead of tcp.